### PR TITLE
Support loading GLB models passed via avatar_url portal param

### DIFF
--- a/public/modules/character.js
+++ b/public/modules/character.js
@@ -3,9 +3,13 @@ import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 import { state } from './state.js';
 
 export function loadPlayerModel() {
+  const params = new URLSearchParams(window.location.search);
+  const avatarUrl = params.get('avatar_url');
+  const modelPath = avatarUrl || 'assets/3d/metaverse-explorer.glb';
+
   const loader = new GLTFLoader();
   loader.load(
-    'assets/3d/metaverse-explorer.glb',
+    modelPath,
     (gltf) => {
       state.playerModel = gltf.scene;
       state.playerModel.traverse((child) => {


### PR DESCRIPTION
When arriving through a portal with an avatar_url query parameter, use that URL to load the player's GLB model instead of the hardcoded default. Falls back to metaverse-explorer.glb when no param is present.